### PR TITLE
Process longer TXT record values

### DIFF
--- a/tests/test_rdata.py
+++ b/tests/test_rdata.py
@@ -635,10 +635,10 @@ class RdataTestCase(unittest.TestCase):
         with self.assertRaises(dns.exception.SyntaxError):
             dns.rdata.from_text('in', 'txt', '')
 
-    def test_too_long_TXT(self):
-        # hit too long
-        with self.assertRaises(dns.exception.SyntaxError):
-            dns.rdata.from_text('in', 'txt', 'a' * 256)
+    def test_long_TXT(self):
+        # long TXT is split at 255 length and does not raise
+        rdata = dns.rdata.from_text('in', 'txt', 'a' * 256)
+        self.assertEqual(rdata.strings, (b'a' * 255, b'a'))
 
     def equal_smimea(self, a, b):
         a = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.SMIMEA, a)
@@ -696,7 +696,7 @@ class RdataTestCase(unittest.TestCase):
                     rr = dns.rdata.from_text('IN', 'DNSKEY', input_variation)
                     new_text = rr.to_text(chunksize=chunksize)
                     self.assertEqual(output, new_text)
-                    
+
     def test_relative_vs_absolute_compare_unstrict(self):
         try:
             saved = dns.rdata._allow_relative_comparisons


### PR DESCRIPTION
Separating them each 255 chars.

squashed
https://github.com/sapcc/dnspython/commit/3a154feefa0955c50d07fb3b58a0d0a0f2c89129 and
https://github.com/sapcc/dnspython/commit/843ad0434e13f503d488586d862ae4f6fe09bf4e and added a simple test case instead of removing the assertRaises.

branch 2023.1-m3 (intended to be 2023.1 with our changes on top) is based on branch 2023.1 which is based on https://github.com/rthalley/dnspython/tree/v2.2.1, because https://github.com/openstack/requirements/blob/92e17ec0794879e010ed4ba754b5ee1246bfe917/upper-constraints.txt#L549 is set to 2.2.1