### PR TITLE
Add setuptools to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ curio = ['curio', 'sniffio']
 wmi = ['wmi']
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core", "setuptools>=64", "setuptools-scm>=8"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
setuptools are required when building the dnspython project.

This fixes `No module named 'setuptools'` in the CI.

